### PR TITLE
Include quaternion offset fix in sprint-06-release-candidate

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -201,7 +201,7 @@ function onDoubleClick(event) {
     convertedAngle = THREE.Math.degToRad(convertedAngle);
     const currentPos = viewerImageAPI.currentImage.pos;
     
-    const newPos = newLocationFromPointAngle(currentPos[0], currentPos[1], convertedAngle, distance)
+    const newPos = newLocationFromPointAngle(currentPos[0], currentPos[1], convertedAngle, distance);
 
     viewerAPI.move(newPos[0], newPos[1], currentPos[2]);
 

--- a/src/js/viewer/ViewerImage.js
+++ b/src/js/viewer/ViewerImage.js
@@ -16,7 +16,12 @@ export class ViewerImage {
     
         this.pos = [panoLon, panoLat, panoZ]; // : [Number] // WGS 84 coordinates [longitude, latitude, z] of this image
 
-        this.orientation = new THREE.Quaternion(x, y, z, w);
+        // The quaternion data available in the json is not quite compatible with the translation we need in our scene
+        const threeX = y;
+        const threeY = z;
+        const threeZ = x;
+
+        this.orientation = new THREE.Quaternion(threeX, threeY, threeZ, w);
 
         this.mapOffset; // : [offsetX, offsetY] // in pixels, offset from map png
         

--- a/src/js/viewer/ViewerPanoAPI.js
+++ b/src/js/viewer/ViewerPanoAPI.js
@@ -21,7 +21,6 @@ export class ViewerPanoAPI{
         sphere.scale(-1, 1, 1);
 
         // load the 360-panorama image data (one specific hardcoded for now)
-        //const texturePano = textureLoader.load('../assets/' + getFolderNumber(this.viewerImageAPI.currentImageId) + '/' + this.viewerImageAPI.currentImageId + 'r3.jpg');
         const texturePano = textureLoader.load(baseURL + getFolderNumber(this.viewerImageAPI.currentImageId) + '/' + this.viewerImageAPI.currentImageId + 'r3.jpg');
         texturePano.mapping = THREE.EquirectangularReflectionMapping; // not sure if this line matters
         
@@ -29,7 +28,9 @@ export class ViewerPanoAPI{
         const material = new THREE.MeshBasicMaterial({ map: texturePano });
         const mesh = new THREE.Mesh(sphere, material);
         const orientation = this.viewerImageAPI.currentImage.orientation;
-        // applyQuaternion(orientation); on something
+        mesh.applyQuaternion(orientation);
+
+        this.scene.clear();
         this.scene.add(mesh);
     }
 
@@ -55,6 +56,7 @@ export class ViewerPanoAPI{
 
     }
 
+    // TODO: remove because can be replaced by viewer longitude offset now
     // angle returned in realtion to real word: +-0 -> north, -90 -> east, +-180 -> south, +90 -> east
     getAngle(){
         var vector = new THREE.Vector3( 0, 0, - 1 );


### PR DESCRIPTION
Apparently the error was in the data.json, what is marked as x, y, z values are actually y, z, x values in this order....At least its working now